### PR TITLE
Allow all 'text' inputs to be disabled

### DIFF
--- a/examples/Form.elm
+++ b/examples/Form.elm
@@ -114,13 +114,13 @@ view model =
                 ]
                 { text = model.username
                 , placeholder = Just (Input.placeholder [] (text "username"))
-                , onChange = \new -> Update { model | username = new }
+                , onChange = Just (\new -> Update { model | username = new })
                 , label = Input.labelAbove [ Font.size 14 ] (text "Username")
                 }
             , Input.currentPassword [ spacing 12, width shrink ]
                 { text = model.password
                 , placeholder = Nothing
-                , onChange = \new -> Update { model | password = new }
+                , onChange = Just (\new -> Update { model | password = new })
                 , label = Input.labelAbove [ Font.size 14 ] (text "Password")
                 , show = False
                 }
@@ -132,7 +132,7 @@ view model =
                 ]
                 { text = model.comment
                 , placeholder = Just (Input.placeholder [] (text "Extra hot sauce?\n\n\nYes pls"))
-                , onChange = \new -> Update { model | comment = new }
+                , onChange = Just (\new -> Update { model | comment = new })
                 , label = Input.labelAbove [ Font.size 14 ] (text "Leave a comment!")
                 , spellcheck = False
                 }

--- a/src/Element/Input.elm
+++ b/src/Element/Input.elm
@@ -586,7 +586,7 @@ type TextKind
 
 {-| -}
 type alias Text msg =
-    { onChange : String -> msg
+    { onChange : Maybe (String -> msg)
     , text : String
     , placeholder : Maybe (Placeholder msg)
     , label : Label msg
@@ -630,7 +630,12 @@ textHelper textInput attrs textOptions =
             Element.width Element.fill :: (defaultTextBoxStyle ++ attrs)
 
         behavior =
-            [ Internal.Attr (Html.Events.onInput textOptions.onChange) ]
+            case textOptions.onChange of
+                Just msg ->
+                    [ Internal.Attr (Html.Events.onInput msg) ]
+
+                Nothing ->
+                    [ Internal.Attr (Html.Attributes.disabled True) ]
 
         noNearbys =
             List.filter (not << forNearby) attributes
@@ -902,7 +907,7 @@ textHelper textInput attrs textOptions =
 text :
     List (Attribute msg)
     ->
-        { onChange : String -> msg
+        { onChange : Maybe (String -> msg)
         , text : String
         , placeholder : Maybe (Placeholder msg)
         , label : Label msg
@@ -921,7 +926,7 @@ text =
 spellChecked :
     List (Attribute msg)
     ->
-        { onChange : String -> msg
+        { onChange : Maybe (String -> msg)
         , text : String
         , placeholder : Maybe (Placeholder msg)
         , label : Label msg
@@ -939,7 +944,7 @@ spellChecked =
 search :
     List (Attribute msg)
     ->
-        { onChange : String -> msg
+        { onChange : Maybe (String -> msg)
         , text : String
         , placeholder : Maybe (Placeholder msg)
         , label : Label msg
@@ -963,7 +968,7 @@ A password takes all the arguments a normal `Input.text` would, and also `show`,
 newPassword :
     List (Attribute msg)
     ->
-        { onChange : String -> msg
+        { onChange : Maybe (String -> msg)
         , text : String
         , placeholder : Maybe (Placeholder msg)
         , label : Label msg
@@ -994,7 +999,7 @@ newPassword attrs pass =
 currentPassword :
     List (Attribute msg)
     ->
-        { onChange : String -> msg
+        { onChange : Maybe (String -> msg)
         , text : String
         , placeholder : Maybe (Placeholder msg)
         , label : Label msg
@@ -1025,7 +1030,7 @@ currentPassword attrs pass =
 username :
     List (Attribute msg)
     ->
-        { onChange : String -> msg
+        { onChange : Maybe (String -> msg)
         , text : String
         , placeholder : Maybe (Placeholder msg)
         , label : Label msg
@@ -1043,7 +1048,7 @@ username =
 email :
     List (Attribute msg)
     ->
-        { onChange : String -> msg
+        { onChange : Maybe (String -> msg)
         , text : String
         , placeholder : Maybe (Placeholder msg)
         , label : Label msg
@@ -1061,7 +1066,7 @@ email =
 multiline :
     List (Attribute msg)
     ->
-        { onChange : String -> msg
+        { onChange : Maybe (String -> msg)
         , text : String
         , placeholder : Maybe (Placeholder msg)
         , label : Label msg


### PR DESCRIPTION
Allows 'text' inputs to be disabled with the same mechanism that Input.button allows.

I am not 100% certain that this works, since I am unsure how to locally do this change in a project (akin to changing a local NPM module source, until it works) but I am relatively confident that this should do the trick. It does pass type checks at least.