### PR TITLE
Mirror 'flex-basis: 0%' from classes.row to classes.column children

### DIFF
--- a/src/Internal/Style.elm
+++ b/src/Internal/Style.elm
@@ -1319,6 +1319,12 @@ baseSheet =
         , Descriptor (dot classes.column)
             [ Prop "display" "flex"
             , Prop "flex-direction" "column"
+            , Child (dot classes.any)
+                [ Prop "flex-basis" "0%"
+                , Descriptor (dot classes.widthExact)
+                    [ Prop "flex-basis" "auto"
+                    ]
+                ]
             , Child (dot classes.heightFill)
                 [ Prop "flex-grow" "100000"
                 ]


### PR DESCRIPTION
Fix #40. Feel free to comment if I need to do anything else on this PR or even if I need to wait for some other design decision of yours.

I couldn't figure out how to make a test case for this, but I can look into it a bit more if requested. Anyway, thank you for the amazing library and take on web design tooling :)