### PR TITLE
Allow batching of attributes

### DIFF
--- a/src/Element.elm
+++ b/src/Element.elm
@@ -3,7 +3,7 @@ module Element exposing
     , row, wrappedRow, column
     , paragraph, textColumn
     , Column, table, IndexedColumn, indexedTable
-    , Attribute, width, height, Length, px, shrink, fill, fillPortion, maximum, minimum
+    , Attribute, width, height, Length, px, shrink, fill, fillPortion, maximum, minimum, batchAttributes
     , explain
     , padding, paddingXY, paddingEach
     , spacing, spacingXY, spaceEvenly
@@ -356,6 +356,16 @@ html =
 htmlAttribute : Html.Attribute msg -> Attribute msg
 htmlAttribute =
     Internal.Attr
+
+
+{-| Batches up multiple attributes as one.
+
+Usefull when composing styles to avoid calls to List.append
+
+-}
+batchAttributes : List (Attribute msg) -> Attribute msg
+batchAttributes batch =
+    Internal.Batch batch
 
 
 {-| -}

--- a/src/Internal/Model.elm
+++ b/src/Internal/Model.elm
@@ -315,6 +315,7 @@ type Attribute aligned msg
     | Height Length
     | Nearby Location (Element msg)
     | TransformComponent Flag TransformComponent
+    | Batch (List (Attribute aligned msg))
 
 
 type TransformComponent
@@ -1257,6 +1258,16 @@ gatherAttrRecursive classes node has transform styles attrs children elementAttr
                             children
                             remaining
 
+                Batch batch ->
+                    gatherAttrRecursive classes
+                        node
+                        has
+                        transform
+                        styles
+                        attrs
+                        children
+                        (List.append batch remaining)
+
 
 addNearbyElement location elem existing =
     let
@@ -1844,67 +1855,79 @@ filter : List (Attribute aligned msg) -> List (Attribute aligned msg)
 filter attrs =
     Tuple.first <|
         List.foldr
-            (\x ( found, has ) ->
-                case x of
-                    NoAttribute ->
-                        ( found, has )
-
-                    Class key _ ->
-                        ( x :: found, has )
-
-                    Attr attr ->
-                        ( x :: found, has )
-
-                    StyleClass _ style ->
-                        ( x :: found, has )
-
-                    Width width ->
-                        if Set.member "width" has then
-                            ( found, has )
-
-                        else
-                            ( x :: found, Set.insert "width" has )
-
-                    Height height ->
-                        if Set.member "height" has then
-                            ( found, has )
-
-                        else
-                            ( x :: found, Set.insert "height" has )
-
-                    Describe description ->
-                        if Set.member "described" has then
-                            ( found, has )
-
-                        else
-                            ( x :: found, Set.insert "described" has )
-
-                    Nearby location elem ->
-                        ( x :: found, has )
-
-                    AlignX _ ->
-                        if Set.member "align-x" has then
-                            ( found, has )
-
-                        else
-                            ( x :: found, Set.insert "align-x" has )
-
-                    AlignY _ ->
-                        if Set.member "align-y" has then
-                            ( found, has )
-
-                        else
-                            ( x :: found, Set.insert "align-y" has )
-
-                    TransformComponent _ _ ->
-                        if Set.member "transform" has then
-                            ( found, has )
-
-                        else
-                            ( x :: found, Set.insert "transform" has )
-            )
+            filterFold
             ( [], Set.empty )
             attrs
+
+
+filterFold :
+    Attribute aligned msg
+    -> ( List (Attribute aligned msg), Set String )
+    -> ( List (Attribute aligned msg), Set String )
+filterFold x ( found, has ) =
+    case x of
+        NoAttribute ->
+            ( found, has )
+
+        Class key _ ->
+            ( x :: found, has )
+
+        Attr attr ->
+            ( x :: found, has )
+
+        StyleClass _ style ->
+            ( x :: found, has )
+
+        Width width ->
+            if Set.member "width" has then
+                ( found, has )
+
+            else
+                ( x :: found, Set.insert "width" has )
+
+        Height height ->
+            if Set.member "height" has then
+                ( found, has )
+
+            else
+                ( x :: found, Set.insert "height" has )
+
+        Describe description ->
+            if Set.member "described" has then
+                ( found, has )
+
+            else
+                ( x :: found, Set.insert "described" has )
+
+        Nearby location elem ->
+            ( x :: found, has )
+
+        AlignX _ ->
+            if Set.member "align-x" has then
+                ( found, has )
+
+            else
+                ( x :: found, Set.insert "align-x" has )
+
+        AlignY _ ->
+            if Set.member "align-y" has then
+                ( found, has )
+
+            else
+                ( x :: found, Set.insert "align-y" has )
+
+        TransformComponent _ _ ->
+            if Set.member "transform" has then
+                ( found, has )
+
+            else
+                ( x :: found, Set.insert "transform" has )
+
+        Batch batch ->
+            List.foldr
+                filterFold
+                ( found, has )
+                batch
 
 
 isContent len =
@@ -3306,6 +3329,9 @@ mapAttr fn attr =
         TransformComponent fl trans ->
             TransformComponent fl trans
 
+        Batch list ->
+            Batch (List.map (mapAttr fn) list)
+
 
 mapAttrFromStyle : (msg -> msg1) -> Attribute Never msg -> Attribute () msg1
 mapAttrFromStyle fn attr =
@@ -3343,6 +3369,9 @@ mapAttrFromStyle fn attr =
 
         TransformComponent fl trans ->
             TransformComponent fl trans
+
+        Batch list ->
+            Batch (List.map (mapAttrFromStyle fn) list)
 
 
 unwrapDecorations : List (Attribute Never Never) -> List Style


### PR DESCRIPTION
When composing styles one might have functions that define borders or fonts or backgrounds etc.
These functions usually need to return `List`s of `Attribute msg`, as more than one attribute is needed to define a border for example.

This can get awkward when using them:

``` elm
el (List.append thinBorder headerFont [ width fill, padding 8]) <| text "Header"
```

This pull requests introduces the `batchAttributes` function:
``` elm
batchAttributes : List (Attribute msg) -> Attribute msg
```

Then, the thinBorder function can return a single `Attribute msg` and the above example becomes simpler:

``` elm
el [thinBorder, headerFont, width fill, padding 8] <| text "Header"
```

With thinBorder looking like:

``` elm
thinBorder : Attribute msg
thinBorder =
    Element.batchAttributes
        [ Border.width 1
        , Border.solid
        , Border.color <| greyscale 0.65
        , Border.rounded 3
        ]
```
