### PR TITLE
Partially fix cursor in input [type=range] in Firefox not displaying

### DIFF
--- a/src/Internal/Style.elm
+++ b/src/Internal/Style.elm
@@ -703,7 +703,8 @@ input[type=range] {
 }
 
 /* Hide all syling for track */
-input[type=range]::-moz-range-track {
+input[type=range]::-moz-range-track,
+input[type=range]::-moz-range-progress {
     background: transparent;
     cursor: pointer;
 }
@@ -733,6 +734,7 @@ input[type=range]::-moz-range-thumb {
     background-color: black;
     border:none;
     border-radius: 5px;
+    cursor: pointer;
 }
 input[type=range]::-ms-thumb {
     opacity: 0.5;


### PR DESCRIPTION
**Note: this does not fix issue 55**, I just found it while working on issue55.
This adds two rules to the `input[type=range]` reset code. They partially address the issue seen here:

https://ellie-app.com/3J7QqtQmcnWa1

If you open that ellie in Chrome, there are no issues. You see the hand pointer whenever the mouse is over the slider or thumb. However, in Firefox (Dev Edition 64.0b1 64 bit on Windows) there are two issues:

1. A hand pointer is only seen when the mouse is over the track on the right side of the thumb. It is missing from the thumb itself and the left side of the track.
2. A hand pointer is only seen in a very narrow region near the center of the slider

The fix addresses the first issue but not the second one. The second one seems more complex to address and I would have to think more about it. Even though I only tested it in Firefox on Windows, I believe this would be a problem for other Firefox versions as well.