### PR TITLE
Add note about flex usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ This means:
 * Everything should just **run fast.**
 * **Layout and style are explicit and easy to modify.** CSS and HTML as tools for a layout language are hard to modify because there's no central place that represents your layout. You're generally forced to bounce back and forth between multiple definitions in multiple files in order to adjust layout, even though it's probably the most common thing you'll do.
 
+However: All of this comes at the small cost of requiring [Flex](https://developer.mozilla.org/en-US/docs/Glossary/Flex).
+If you are not sure whether your target browser supports it, check out [this support table](https://caniuse.com/#feat=flexbox).
+But today most, if not all, major browsers allow the use of Flex, so you shouldn't have to worry about it in most cases.
+
 
 [Try this live example on Ellie!](https://ellie-app.com/3f2n4J5RnT3a1)
 


### PR DESCRIPTION
I noticed that this package uses flex when I inspected some css rules. Since I am in a position where I can't use that, because I need to support older browsers, I thought it would have been helpful had I known earlier about that. So I added a small note to the README.
Still, this library was totally awesome to use so far and I will definitely choose it for future projects where there's no requirement for browsers from the last decade.
