### PR TITLE
Make classifyDevice's DeviceClass based on the shorter side of the window.

### DIFF
--- a/src/Element.elm
+++ b/src/Element.elm
@@ -1563,6 +1563,7 @@ classifyDevice window =
             Landscape
     }
 
+
 {-| When designing it's nice to use a modular scale to set spacial rythms.
 
     scaled =

--- a/src/Element.elm
+++ b/src/Element.elm
@@ -1536,13 +1536,21 @@ type Orientation
 classifyDevice : { window | height : Int, width : Int } -> Device
 classifyDevice window =
     { class =
-        if window.width <= 600 then
+        let
+            shortSide =
+                if window.width < window.height then
+                    window.width
+
+                else
+                    window.height
+        in
+        if shortSide <= 600 then
             Phone
 
-        else if window.width > 600 && window.width <= 1200 then
+        else if shortSide > 600 && shortSide <= 1200 then
             Tablet
 
-        else if window.width > 1200 && window.width <= 1800 then
+        else if shortSide > 1200 && shortSide <= 1800 then
             Desktop
 
         else
@@ -1554,7 +1562,6 @@ classifyDevice window =
         else
             Landscape
     }
-
 
 {-| When designing it's nice to use a modular scale to set spacial rythms.
 


### PR DESCRIPTION
This should help make the resulting DeviceClass more consistent.