### PR TITLE
Change the order of text input type and value attributes

### DIFF
--- a/src/Element/Input.elm
+++ b/src/Element/Input.elm
@@ -741,8 +741,8 @@ textHelper textInput attrs textOptions =
             case textInput.type_ of
                 TextInputNode inputType ->
                     ( "input"
-                    , [ value textOptions.text
-                      , Internal.Attr (Html.Attributes.type_ inputType)
+                    , [ Internal.Attr (Html.Attributes.type_ inputType)
+                      , value textOptions.text
                       , spellcheck textInput.spellchecked
                       , Internal.htmlClass classes.inputText
                       , case textInput.autofill of


### PR DESCRIPTION
This works around a rather obscure bug in Microsoft Edge.

Basically, I want to use an input with type date (knowing well that
not every browser implements it), so I use:

```elm
Element.Input.text [ htmlAttribute <| Html.Attributes.type_ "date" ]
```

This works well in most browsers, but it seems to trigger a weird edge
case bug in Microsoft Edge where it renders the date text _twice_, first
in ISO8601, then in the normal way it renders dates in inputs with type
date. So the text box contains both the texts "2019-03-08" and
"3/8/2019".

After quite a lot of experimentation, I found out that switching the
order of these two attributes fixes the problem. I can only speculate as
to why, but whatever it is it seems like it should be benign change to
make.

Here's what it looks like in my app without this patch:

![2019-03-06-124451_948x223_scrot](https://user-images.githubusercontent.com/197549/54020738-c6eb9480-418e-11e9-866a-8eb1ceceb04c.png)

and here's with:

![2019-03-08-104217_883x204_scrot](https://user-images.githubusercontent.com/197549/54020826-02865e80-418f-11e9-8ea3-76964dde8b06.png)