### PR TITLE
Some typo fixes and a basic numeric textbox (optional)

### DIFF
--- a/src/Element.elm
+++ b/src/Element.elm
@@ -34,7 +34,7 @@ module Element exposing
 
 # Rows and Columns
 
-When we want more than one child on an element, we want to be _specific_ about how they will be layed out.
+When we want more than one child on an element, we want to be _specific_ about how they will be laid out.
 
 So, the common ways to do that would be `row` and `column`.
 
@@ -1442,7 +1442,7 @@ transparent on =
 
 {-| A capped value between 0.0 and 1.0, where 0.0 is transparent and 1.0 is fully opaque.
 
-Semantically equavalent to html opacity.
+Semantically equivalent to html opacity.
 
 -}
 alpha : Float -> Attr decorative msg
@@ -1559,7 +1559,7 @@ classifyDevice window =
 {-| When designing it's nice to use a modular scale to set spacial rythms.
 
     scaled =
-        Scale.modular 16 1.25
+        modular 16 1.25
 
 A modular scale starts with a number, and multiplies it by a ratio a number of times.
 Then, when setting font sizes you can use:

--- a/src/Element/Input.elm
+++ b/src/Element/Input.elm
@@ -8,6 +8,7 @@ module Element.Input exposing
     , radio, radioRow, Option, option, optionWith, OptionState(..)
     , Label, labelAbove, labelBelow, labelLeft, labelRight, labelHidden
     , focusedOnLoad
+    , numericText
     )
 
 {-|
@@ -1158,6 +1159,41 @@ username =
         , spellchecked = False
         , autofill = Just "username"
         }
+
+
+{-| -}
+numericText :
+    { min : Maybe Float
+    , max : Maybe Float
+    , step : Maybe Float
+    }
+    -> List (Attribute msg)
+    ->
+        { onChange : String -> msg
+        , text : String
+        , placeholder : Maybe (Placeholder msg)
+        , label : Label msg
+        }
+    -> Element msg
+numericText { min, max, step } attrs =
+    let
+        asAttrList mf attr =
+            mf
+                |> Maybe.map (\m -> [ Element.htmlAttribute (attr (String.fromFloat m)) ])
+                |> Maybe.withDefault []
+
+        mergedAttrs =
+            asAttrList min Html.Attributes.min
+                ++ asAttrList max Html.Attributes.max
+                ++ asAttrList step Html.Attributes.step
+                ++ attrs
+    in
+    textHelper
+        { type_ = TextInputNode "number"
+        , spellchecked = False
+        , autofill = Just "number"
+        }
+        mergedAttrs
 
 
 {-| -}


### PR DESCRIPTION
A couple of typos and a word that shouldn't be there in Element.elm.
And a basic numeric text box I added a few months ago for my own use, which you MAY want to include.