### PR TITLE
Add note about text alignment to `Element` alignment section

### DIFF
--- a/src/Element.elm
+++ b/src/Element.elm
@@ -109,6 +109,8 @@ will result in a layout like
 
 Where there are two elements on the left, one in the center, and one on the right.
 
+**Note** For text alignment, check out `Element.Font`!
+
 @docs centerX, centerY, alignLeft, alignRight, alignTop, alignBottom
 
 


### PR DESCRIPTION
Trying to reduce confusion between elements and text alignment.

Closes #99 .