### PR TITLE
Fix classpath of Element.modular in documentation

### DIFF
--- a/src/Element.elm
+++ b/src/Element.elm
@@ -1559,7 +1559,7 @@ classifyDevice window =
 {-| When designing it's nice to use a modular scale to set spacial rythms.
 
     scaled =
-        Scale.modular 16 1.25
+        Element.modular 16 1.25
 
 A modular scale starts with a number, and multiplies it by a ratio a number of times.
 Then, when setting font sizes you can use:


### PR DESCRIPTION
Hi Matthew,

unless I am mistaken, there is no `Scale` module, instead modular is defined directly inside the `Element`. But the documentation of `Element.modular` refers to it as `Scale.modular`. If that is not intentional, this pull request will fix it.