### PR TITLE
Remove out of date reference to `fillBetween`

### DIFF
--- a/notes/CHANGES-FROM-STYLE-ELEMENTS.md
+++ b/notes/CHANGES-FROM-STYLE-ELEMENTS.md
@@ -119,7 +119,7 @@ Also of note, is that if something is `center`, then it will truly be in the cen
 
 - `Font.weight` has been removed in favor of `Font.extraBold`, `Font.regular`, `Font.light`, etc.  All weights from 100 - 900 are represented.
 - `Background.image` and `Background.fittedImage` will place a centered background image, instead of anchoring at the top left.
-- `fill |> minimum 20 |> maximum 200` is now present for `minWidth`, `maxWidth`, `maxWidth` and `maxHeight` behavior.  It works like fill, but with an optional top and lower bound.
+- `fill |> minimum 20 |> maximum 200` is now present for `minWidth`, `maxWidth`, `minHeight` and `maxHeight` behavior.  It works like fill, but with an optional top and lower bound.
 - `transparent` - Set an element as transparent.  It will take up space, but otherwise be transparent and unclickable.
 - `alpha` can now be set for an element.
 - `attribute` has been renamed `htmlAttribute` to better convey what it's used for.

--- a/notes/CHANGES-FROM-STYLE-ELEMENTS.md
+++ b/notes/CHANGES-FROM-STYLE-ELEMENTS.md
@@ -119,7 +119,7 @@ Also of note, is that if something is `center`, then it will truly be in the cen
 
 - `Font.weight` has been removed in favor of `Font.extraBold`, `Font.regular`, `Font.light`, etc.  All weights from 100 - 900 are represented.
 - `Background.image` and `Background.fittedImage` will place a centered background image, instead of anchoring at the top left.
-- `fillBetween { min : Maybe Int, max : Maybe Int}` is now present for `min/max height/width` behavior.  It works like fill, but with an optional top and lower bound.
+- `fill |> minimum 20 |> maximum 200` is now present for `minWidth`, `maxWidth`, `maxWidth` and `maxHeight` behavior.  It works like fill, but with an optional top and lower bound.
 - `transparent` - Set an element as transparent.  It will take up space, but otherwise be transparent and unclickable.
 - `alpha` can now be set for an element.
 - `attribute` has been renamed `htmlAttribute` to better convey what it's used for.


### PR DESCRIPTION
And replace with current syntax for setting min and max dimensions.

I have included the names of all the old properties (`minWidth` etc), so that they show up when searching