### PR TITLE
fix fillPortion docs

### DIFF
--- a/src/Element.elm
+++ b/src/Element.elm
@@ -427,9 +427,16 @@ maximum i l =
     Internal.Max i l
 
 
-{-| Sometimes you may not want to split available space evenly. In this case you can use `fillPortion` to define which elements should have what portion of the available space.
+{-| `fillPortion` is currently just a proxy for `flex-grow`, which is sometimes misunderstood to specify length
+as a portion of the parent's length, relative to siblings' `flex-grow` values. In fact, `flex-grow` only governs 
+distribution of *excess* space along the parent's central flex axis—that is, space that remains *after* the 
+children have been rendered once. So, `fillPortion` does not yet behave exactly as its name implies (unless you're 
+so fluent in CSS that this is not surprising to you!).
 
-So, two elements, one with `width (fillPortion 2)` and one with `width (fillPortion 3)`. The first would get 2 portions of the available space, while the second would get 3.
+As a workaround, in order to express length as a portion of the parent's central axis and relative to siblings'
+`fillPortion` values, you must also set the width on the children to 0 (probably using a custom css class); this 
+will allow `flex-grow` to distribute the entirety of the parent's length to its children according to their `fillPortion`
+values.
 
 **Also:** `fill == fillPortion 1`
 

--- a/src/Element.elm
+++ b/src/Element.elm
@@ -427,16 +427,17 @@ maximum i l =
     Internal.Max i l
 
 
-{-| `fillPortion` is currently just a proxy for `flex-grow`, which is sometimes misunderstood to specify length
-as a portion of the parent's length, relative to siblings' `flex-grow` values. In fact, `flex-grow` only governs 
-distribution of *excess* space along the parent's central flex axis—that is, space that remains *after* the 
-children have been rendered once. So, `fillPortion` does not yet behave exactly as its name implies (unless you're 
-so fluent in CSS that this is not surprising to you!).
+{-| `fillPortion` is currently just a proxy for `flex-grow`, which is sometimes misunderstood 
+to specify length as a portion of the parent's length, relative to siblings' `flex-grow` values. 
+In fact, `flex-grow` only governs distribution of *excess* space along the parent's central flex 
+axis—that is, space that remains *after* the children have been rendered once. So, `fillPortion` 
+does not yet behave exactly as its name implies (unless you're so fluent in CSS that this is not 
+surprising to you!).
 
-As a workaround, in order to express length as a portion of the parent's central axis and relative to siblings'
-`fillPortion` values, you must also set the width on the children to 0 (probably using a custom css class); this 
-will allow `flex-grow` to distribute the entirety of the parent's length to its children according to their `fillPortion`
-values.
+As a workaround, in order to express length as a portion of the parent's central axis and relative 
+to siblings' `fillPortion` values, you must also set the width on the children to 0 (probably using 
+a custom css class); this will allow `flex-grow` to distribute the entirety of the parent's length 
+to its children according to their `fillPortion` values.
 
 **Also:** `fill == fillPortion 1`
 


### PR DESCRIPTION
I think the right fix here is actually at the implementation level (i.e., make fillPortion do what its name implies w/o hacks), but that might require exposing the normal flex-grow behavior via the API somehow. I'd be happy to take a crack at that given the go-ahead, but in the meantime, an acknowledgement like the one proposed would likely save folks some time.