### PR TITLE
Add note about altering line-height of Input.multiline

### DIFF
--- a/src/Element/Input.elm
+++ b/src/Element/Input.elm
@@ -1565,6 +1565,8 @@ email =
 
 By default it will have a minimum height of one line and resize based on it's contents.
 
+Use `Element.spacing` to change its line-height.
+
 -}
 multiline :
     List (Attribute msg)


### PR DESCRIPTION
`Element.spacing` applied to an `Input.multiline` appears to alter the line-height of the textarea, just like applying `Element.spacing` to an `Element.paragraph` would. However, although I don't think it's unreasonable to guess that a user might attempt this combination in order to alter the line-height of an `Input.multiline`, I personally didn't think to because it's not documented!