### PR TITLE
Add Element.Region "header"

### DIFF
--- a/src/Element/Region.elm
+++ b/src/Element/Region.elm
@@ -1,5 +1,5 @@
 module Element.Region exposing
-    ( mainContent, navigation, heading, aside, footer
+    ( header, mainContent, navigation, heading, aside, footer
     , description
     , announce, announceUrgently
     )
@@ -19,7 +19,7 @@ Here's an example of annotating your navigation region:
             [-- ..your navigation links
             ]
 
-@docs mainContent, navigation, heading, aside, footer
+@docs header, mainContent, navigation, heading, aside, footer
 
 @docs description
 
@@ -29,6 +29,12 @@ Here's an example of annotating your navigation region:
 
 import Element exposing (Attribute)
 import Internal.Model as Internal exposing (Description(..))
+
+
+{-| -}
+header : Attribute msg
+header =
+    Internal.Describe Header
 
 
 {-| -}

--- a/src/Internal/Model.elm
+++ b/src/Internal/Model.elm
@@ -326,6 +326,7 @@ type TransformComponent
 
 type Description
     = Main
+    | Header
     | Navigation
       -- | Search
     | ContentInfo
@@ -1121,6 +1122,9 @@ gatherAttrRecursive classes node has transform styles attrs children elementAttr
                     case description of
                         Main ->
                             gatherAttrRecursive classes (addNodeName "main" node) has transform styles attrs children remaining
+
+                        Header ->
+                            gatherAttrRecursive classes (addNodeName "header" node) has transform styles attrs children remaining
 
                         Navigation ->
                             gatherAttrRecursive classes (addNodeName "nav" node) has transform styles attrs children remaining

--- a/tests-rendering/cases/Manual/Regions.elm
+++ b/tests-rendering/cases/Manual/Regions.elm
@@ -1,0 +1,43 @@
+module Tests.Manual.Regions exposing (..)
+
+import Browser
+import Element exposing (..)
+import Element.Region as Region
+import Html
+import Html.Attributes
+
+
+type alias Model =
+    {}
+
+
+init : () -> ( Model, Cmd Msg )
+init flags =
+    ( {}, Cmd.none )
+
+
+type Msg
+    = NoOp
+
+
+update msg model =
+    case msg of
+        NoOp ->
+            ( model, Cmd.none )
+
+
+header =
+    el [ Region.header ] (el [ Region.heading 1 ] (text "This is a h1 in a header"))
+
+
+view model =
+    Element.layout [] (Element.column [] [ header ])
+
+
+main =
+    Browser.element
+        { init = init
+        , view = view
+        , update = update
+        , subscriptions = \_ -> Sub.none
+        }


### PR DESCRIPTION
Regions for `main`, `footer`, `aside`, etc. were already implemented but `header` was missing.

Fixes https://github.com/mdgriffith/elm-ui/issues/59
