### PR TITLE
Improve documentation for newTabLink

### DIFF
--- a/src/Element.elm
+++ b/src/Element.elm
@@ -1173,7 +1173,7 @@ link attrs { url, label } =
         (Internal.Unkeyed [ label ])
 
 
-{-| -}
+{-| Creates a link that on click opens in a new browser tab. Used the same way as @link -}
 newTabLink :
     List (Attribute msg)
     ->


### PR DESCRIPTION
Hi! I just got myself confused about newTabLink, thinking in the sense of that it was meant to be used when I changes tabs in my own app, so delved into the source code to understand it as there wasn't documentation.

I now get that it of course means a new browser tab which makes sense, but just thought I'd add that to the documentation.

Do I not remember correctly that `@link` will link to the link documentation? Or do I write it as a markdown link with the `#`?