### PR TITLE
toGridLengthHelper: fix double "fr" on "minmax"

### DIFF
--- a/src/Internal/Model.elm
+++ b/src/Internal/Model.elm
@@ -2941,7 +2941,7 @@ renderStyleRule options rule maybePseudo =
                                     String.fromInt i ++ "fr"
 
                                 ( Just minSize, Nothing ) ->
-                                    "minmax(" ++ String.fromInt minSize ++ "px, " ++ String.fromInt i ++ "fr" ++ "fr)"
+                                    "minmax(" ++ String.fromInt minSize ++ "px, " ++ String.fromInt i ++ "fr)"
 
                                 ( Nothing, Just maxSize ) ->
                                     "minmax(max-content, " ++ String.fromInt maxSize ++ "px)"


### PR DESCRIPTION
### Expected behavior

`fillPortion 128 |> minimum 1` should create a grid column with `minmax(1px, 128fr)`.

### Current behavior

CSS was generating something like:

```css
.grid-rows-auto-cols-min1128fr-88fr-140fr-142fr-216fr-space-x-0px-space-y-0px {
  grid-template-columns: minmax(1px, 128frfr) 88fr 140fr 142fr 216fr;
  # etc etc etc
}
```

The `frfr` breaks the entire rule. And the browser goes wild.

### Suggested fix

Remove the repetition, `s/frfr/fr/`.

There are no tests covering grid, so I also didn't add one for this issue.

